### PR TITLE
LCD-49361 add support to helm charts for loading extensions from s3 buckets

### DIFF
--- a/cloud/helm/aws/Chart.yaml
+++ b/cloud/helm/aws/Chart.yaml
@@ -7,10 +7,10 @@ dependencies:
         version: 0.1.0
     -   name: liferay-default
         repository: file://../default
-        version: 0.1.3
+        version: 0.1.4
 description:
     Liferay is an all-in-one DXP, LCAP, and Commerce platform. This chart is optimized for AWS.
 icon: https://www-cdn.liferay.com/documents/d/guest/liferay-logo
 name: liferay-aws
 type: application
-version: 0.1.4
+version: 0.1.5

--- a/cloud/helm/aws/values.yaml
+++ b/cloud/helm/aws/values.yaml
@@ -32,6 +32,35 @@ liferay-default:
         x-liferay-aws:
             -   secretRef:
                     name: managed-service-details
+    customInitContainers:
+        x-liferay-copy-extensions:
+            -   containerTemplate: |
+                    -   command:
+                            -   bash
+                            -   -c
+                            -   |
+                                    {{- if and .extensions .extensions.enabled }}
+                                    {{- $extensions := .extensions -}}
+                                    {{- range $extensions.dirs }}
+                                    tree /mnt/liferay/
+                                    mkdir -p /temp/{{ . }}
+                                    cp -R /mnt/liferay/extensions/{{ . }}/* /temp/{{ . }}
+                                    tree /temp/{{ . }}
+                                    {{- end }}
+                                    {{- else }}
+                                    echo "Copying extensions not enabled."
+                                    {{- end }}
+                        image: {{ printf "%s:%s" .image.repository (.image.tag | toString) }}
+                        imagePullPolicy: {{ .image.pullPolicy }}
+                        name: liferay-copy-extensions
+                        {{- if and .extensions .extensions.enabled }}
+                        volumeMounts:
+                            -   mountPath: /mnt/liferay/extensions
+                                name: {{ .extensions.bucketName }}
+                                subPath: {{ .extensions.bucketPath }}
+                            -   mountPath: /temp
+                                name: liferay-persistent-volume
+                        {{- end }}
     customLabels:
         origin: liferay-aws
     customVolumeMounts:

--- a/cloud/helm/default/Chart.yaml
+++ b/cloud/helm/default/Chart.yaml
@@ -5,4 +5,4 @@ description:
 icon: https://www-cdn.liferay.com/documents/d/guest/liferay-logo
 name: liferay-default
 type: application
-version: 0.1.3
+version: 0.1.4

--- a/cloud/helm/default/templates/_statefulset.tpl
+++ b/cloud/helm/default/templates/_statefulset.tpl
@@ -145,6 +145,11 @@ spec:
                 {{- with .statefulset.volumes }}
                 {{- toYaml . | nindent 16 }}
                 {{- end }}
+                {{- if and .statefulset.extensions .statefulset.extensions.enabled }}
+                -   name: {{ .statefulset.extensions.bucketName }}
+                    persistentVolumeClaim:
+                        claimName: {{ .statefulset.extensions.bucketName }}
+                {{- end }}
                 {{- range $k, $v := .statefulset.customVolumes }}
                 {{- toYaml $v | nindent 16 }}
                 {{- end }}

--- a/cloud/helm/default/templates/extensions-storage.yaml
+++ b/cloud/helm/default/templates/extensions-storage.yaml
@@ -1,0 +1,32 @@
+{{- if and .Values.extensions .Values.extensions.enabled }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+    name: {{ .Values.extensions.bucketName }}
+spec:
+    accessModes:
+        -   ReadWriteMany
+    capacity:
+        storage: 10Gi
+    claimRef:
+        name: {{ .Values.extensions.bucketName }}
+        namespace: {{ .Release.Namespace }}
+    csi:
+        driver: s3.csi.aws.com
+        volumeAttributes:
+            bucketName: {{ .Values.extensions.bucketName }}
+        volumeHandle: {{ .Values.extensions.bucketName }}
+    storageClassName: {{ .Values.extensions.bucketName }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+    name: {{ .Values.extensions.bucketName }}
+spec:
+    accessModes:
+        -   ReadWriteMany
+    resources:
+        requests:
+            storage: 10Gi
+    storageClassName: {{ .Values.extensions.bucketName }}
+{{- end }}

--- a/cloud/helm/default/values.yaml
+++ b/cloud/helm/default/values.yaml
@@ -152,6 +152,11 @@ env:
 envFrom:
     -   secretRef:
             name: liferay-default
+extensions:
+    bucketName: ""
+    bucketPath: ""
+    dirs: []
+    enabled: false
 fullnameOverride: ""
 image:
     pullPolicy: IfNotPresent
@@ -279,6 +284,9 @@ volumeMounts:
     -   mountPath: /opt/liferay/metrics
         name: liferay-persistent-volume
         subPath: liferay/metrics
+    -   mountPath: /opt/liferay/osgi/client-extensions
+        name: liferay-persistent-volume
+        subPath: osgi/client-extensions
     -   mountPath: /opt/liferay/osgi/configs
         name: liferay-persistent-volume
         subPath: osgi/configs

--- a/cloud/terraform/aws/dependencies/liferay.tf
+++ b/cloud/terraform/aws/dependencies/liferay.tf
@@ -277,6 +277,20 @@ resource "kubernetes_storage_class" "gp3_storage_class" {
 	storage_provisioner="ebs.csi.eks.amazonaws.com"
 	volume_binding_mode="Immediate"
 }
+resource "kubernetes_storage_class" "liferay_extensions_storage" {
+  allow_volume_expansion=false
+	depends_on=[
+		module.s3_bucket_liferay_extensions
+	]
+  metadata {
+    name=module.s3_bucket_liferay_extensions.s3_bucket_id
+  }
+  parameters={
+    "bucketName"=module.s3_bucket_liferay_extensions.s3_bucket_id
+  }
+  storage_provisioner="s3.csi.aws.com"
+  volume_binding_mode="WaitForFirstConsumer"
+}
 resource "null_resource" "opensearch_service_role" {
 	provisioner "local-exec" {
 		command=<<-EOT


### PR DESCRIPTION
Here is an example values.yaml that a customer would use to load extensions from a s3 bucket on aws
```
liferay-default:
    extensions:
        bucketName: greg-test-49360a-extensions-20260106211939818700000001
        bucketPath: extensions_drop_01
        dirs:
            - osgi/client-extensions
            - osgi/modules
        enabled: true
        storageDriver: s3.csi.aws.com
```