### PR TITLE
LCD-49522 move to default chart and use more flexible from/into const…

### DIFF
--- a/cloud/helm/aws/Chart.yaml
+++ b/cloud/helm/aws/Chart.yaml
@@ -7,10 +7,10 @@ dependencies:
         version: 0.1.0
     -   name: liferay-default
         repository: file://../default
-        version: 0.1.4
+        version: 0.1.5
 description:
     Liferay is an all-in-one DXP, LCAP, and Commerce platform. This chart is optimized for AWS.
 icon: https://www-cdn.liferay.com/documents/d/guest/liferay-logo
 name: liferay-aws
 type: application
-version: 0.1.5
+version: 0.1.6

--- a/cloud/helm/aws/values.yaml
+++ b/cloud/helm/aws/values.yaml
@@ -32,35 +32,6 @@ liferay-default:
         x-liferay-aws:
             -   secretRef:
                     name: managed-service-details
-    customInitContainers:
-        x-liferay-overlay:
-            -   containerTemplate: |
-                    -   command:
-                            -   bash
-                            -   -c
-                            -   |
-                                    {{- if and .overlay .overlay.enabled }}
-                                    {{- $overlay := .overlay -}}
-                                    {{- range $overlay.dirs }}
-                                    tree /mnt/liferay/
-                                    mkdir -p /temp/{{ . }}
-                                    cp -R /mnt/liferay/overlay/{{ . }}/* /temp/{{ . }}
-                                    tree /temp/{{ . }}
-                                    {{- end }}
-                                    {{- else }}
-                                    echo "Overlay is not enabled."
-                                    {{- end }}
-                        image: {{ printf "%s:%s" .image.repository (.image.tag | toString) }}
-                        imagePullPolicy: {{ .image.pullPolicy }}
-                        name: liferay-overlay
-                        {{- if and .overlay .overlay.enabled }}
-                        volumeMounts:
-                            -   mountPath: /mnt/liferay/overlay
-                                name: {{ .overlay.bucketName }}
-                                subPath: {{ .overlay.bucketPath }}
-                            -   mountPath: /temp
-                                name: liferay-persistent-volume
-                        {{- end }}
     customLabels:
         origin: liferay-aws
     customVolumeMounts:

--- a/cloud/helm/default/Chart.yaml
+++ b/cloud/helm/default/Chart.yaml
@@ -5,4 +5,4 @@ description:
 icon: https://www-cdn.liferay.com/documents/d/guest/liferay-logo
 name: liferay-default
 type: application
-version: 0.1.4
+version: 0.1.5

--- a/cloud/helm/default/values.yaml
+++ b/cloud/helm/default/values.yaml
@@ -19,6 +19,39 @@ configmap:
 customEnv: {}
 customEnvFrom: {}
 customInitContainers:
+    x-liferay-overlay:
+        -   containerTemplate: |
+                -   command:
+                        -   bash
+                        -   -c
+                        -   |
+                                {{- if and .overlay .overlay.enabled }}
+                                {{- $overlay := .overlay -}}
+                                {{- range $overlay.copy }}
+                                mkdir \
+                                    --parents \
+                                    --verbose \
+                                    /temp/{{ .into }}
+
+                                cp \
+                                    --recursive \
+                                    --verbose \
+                                    /mnt/liferay/overlay/{{ .from }} \
+                                    /temp/{{ .into }}
+                                {{- end }}
+                                {{- else }}
+                                echo "Overlay is not enabled."
+                                {{- end }}
+                    image: {{ printf "%s:%s" .image.repository (.image.tag | toString) }}
+                    imagePullPolicy: {{ .image.pullPolicy }}
+                    name: liferay-overlay
+                    {{- if and .overlay .overlay.enabled }}
+                    volumeMounts:
+                        -   mountPath: /mnt/liferay/overlay
+                            name: {{ .overlay.bucketName }}
+                        -   mountPath: /temp
+                            name: liferay-persistent-volume
+                   {{- end }}
     x-liferay-prepopulate-data:
         -   containerTemplate: |
                 -   command:
@@ -177,9 +210,8 @@ nameOverride: ""
 nodeSelector: {}
 overlay:
     bucketName: ""
-    bucketPath: ""
-    dirs: []
-    enabled: false
+    copy: []
+    enabled: false 
 podAnnotations: {}
 podLabels: {}
 podSecurityContext:


### PR DESCRIPTION
…ruct

This moves the overlay support into the default helm chart so it can be shared by all cloud providers.  Also this makes the copy operation more flexible, below is the updated syntax how to use
```
overlay:
    bucketName: ""
    copy:
        - from: builds_01/osgi/modules/*
          into: osgi/modules
        - from: common/third-party/*
          into: osgi/modules 
        - from: files/license.xml 
          into: deploy 
      enabled: true
```