### PR TITLE
LCD-49714 always enable portlet session replication

### DIFF
--- a/cloud/helm/aws-marketplace/Chart.yaml
+++ b/cloud/helm/aws-marketplace/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: latest
 dependencies:
     -   name: liferay-aws
         repository: file://../aws
-        version: 0.1.4
+        version: 0.2.0
 description:
     Liferay is an all-in-one DXP, LCAP, and Commerce platform. This chart is optimized for AWS Marketplace.
 icon: https://www-cdn.liferay.com/documents/d/guest/liferay-logo
 name: liferay-aws-marketplace
 type: application
-version: 0.1.15
+version: 0.1.16

--- a/cloud/helm/aws/Chart.yaml
+++ b/cloud/helm/aws/Chart.yaml
@@ -7,10 +7,10 @@ dependencies:
         version: 0.1.0
     -   name: liferay-default
         repository: file://../default
-        version: 0.1.5
+        version: 0.2.0
 description:
     Liferay is an all-in-one DXP, LCAP, and Commerce platform. This chart is optimized for AWS.
 icon: https://www-cdn.liferay.com/documents/d/guest/liferay-logo
 name: liferay-aws
 type: application
-version: 0.1.6
+version: 0.2.0

--- a/cloud/helm/default/Chart.yaml
+++ b/cloud/helm/default/Chart.yaml
@@ -5,4 +5,4 @@ description:
 icon: https://www-cdn.liferay.com/documents/d/guest/liferay-logo
 name: liferay-default
 type: application
-version: 0.1.5
+version: 0.2.0

--- a/cloud/helm/default/templates/configmap.yaml
+++ b/cloud/helm/default/templates/configmap.yaml
@@ -75,7 +75,6 @@ data:
         cluster.link.channel.properties.transport.0=/opt/liferay/unicast.xml
         cluster.link.enabled=true
         enterprise.product.notification.enabled=false
-        portlet.session.replicate.enabled=true
         {{ end }}
         {{- tpl (.Files.Get "resources/portal-cloud.properties") $ | nindent 8 }}
     portal-ext.properties: |

--- a/cloud/helm/default/values.yaml
+++ b/cloud/helm/default/values.yaml
@@ -164,6 +164,8 @@ env:
         value: ${env.POD_IP}
     -   name: LIFERAY_PORTAL_PERIOD_INSTANCE_PERIOD_INET_PERIOD_SOCKET_PERIOD_ADDRESS
         value: ${env.POD_IP}:8080
+    -   name: LIFERAY_PORTLET_PERIOD_SESSION_PERIOD_REPLICATE_PERIOD_ENABLED
+        value: "true"
     -   name: LIFERAY_TOMCAT_SESSION_REPLICATION_ENABLED
         value: "true"
     -   name: POD_APP


### PR DESCRIPTION
Since the liferay-default helm chart always assumes that the tomcat
cluster session replication is overridden by our own Liferay component,
we must always enable the liferay portlet session replication since
LiferayDeltaManager assumes it.
