### PR TITLE
give users ability to add extra k8s manifests when installing chart

### DIFF
--- a/cloud/helm/default/templates/extra-manifests.yaml
+++ b/cloud/helm/default/templates/extra-manifests.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.customObjects }}
+{{- range $v := .Values.customObjects }}
+{{- range $v }}
+---
+{{- if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/cloud/helm/default/values.yaml
+++ b/cloud/helm/default/values.yaml
@@ -148,6 +148,7 @@ customInitContainers:
                     name: liferay-wait-on-services
 customLabels:
     origin: liferay-cloud
+customObjects: {}
 customPorts: {}
 customPullSecrets: {}
 customServicePorts: {}


### PR DESCRIPTION
This can be used in the following way (add a custom service to enable debugging)
```
customObjects:
  x-jpda-enabled:
    - |
      apiVersion: v1
      kind: Service
      metadata:
        name: {{ include "liferay.name" . }}-jpda
      spec:
        selector:
          app: {{ include "liferay.name" . }}
          app.kubernetes.io/instance: liferay
          app.kubernetes.io/name: {{ include "liferay.name" . }}
        ports:
          - protocol: TCP
            port: 8000
            targetPort: 8000
            nodePort: 30000
        publishNotReadyAddresses: true
        type: NodePort
```